### PR TITLE
Fix duplicate columns in SELECT query

### DIFF
--- a/lib/columns_on_demand.rb
+++ b/lib/columns_on_demand.rb
@@ -192,8 +192,7 @@ module ColumnsOnDemand
       if select_values.empty? && klass < ColumnsOnDemand::InstanceMethods
         arel.project(*arel_columns([default_select(true)]))
       else
-        build_select_without_columns_on_demand(arel)
-        arel.project(*arel_columns(select_values.uniq))
+        build_select_without_columns_on_demand(arel)        
       end
     end
   end

--- a/test/columns_on_demand_test.rb
+++ b/test/columns_on_demand_test.rb
@@ -290,4 +290,11 @@ class ColumnsOnDemandTest < ActiveSupport::TestCase
     assert_not_loaded record, "data"
     assert_equal "replacement", record.data
   end
+
+  test "it doesn't create duplicate columns in SELECT queries" do
+    implicits = Arel::Table.new(:implicits)
+    reference_sql = implicits.project(implicits[:id]).to_sql
+    select_sql = Implicit.select("id").to_sql    
+    assert_equal select_sql, reference_sql
+  end
 end


### PR DESCRIPTION
Seems like columns_on_demand creates duplicate columns in the SELECT clause when ActiveRecord::Relation#select is used: 

    pry(main)> Project.select("id")
    Project Load (3.0ms)  SELECT "projects"."id", "projects"."id" FROM "projects"

I've tested this against PostgreSQL and Rails versions 4.1.2, 4.2.0, 4.2.1, 4.2.3