### PR TITLE
Skip on demand columns when selecting * (e.g. when preloading included associations)

### DIFF
--- a/lib/columns_on_demand.rb
+++ b/lib/columns_on_demand.rb
@@ -179,7 +179,7 @@ module ColumnsOnDemand
 
   module RelationMethodsArity2
     def build_select_with_columns_on_demand(arel, selects)
-      if selects.empty? && klass < ColumnsOnDemand::InstanceMethods
+      if (selects.empty? || selects == [table[Arel.star]] || selects == ['*']) && klass < ColumnsOnDemand::InstanceMethods
         build_select_without_columns_on_demand(arel, [default_select(true)])
       else
         build_select_without_columns_on_demand(arel, selects)
@@ -189,7 +189,7 @@ module ColumnsOnDemand
 
   module RelationMethodsArity1
     def build_select_with_columns_on_demand(arel)
-      if select_values.empty? && klass < ColumnsOnDemand::InstanceMethods
+      if (select_values.empty? || select_values == [table[Arel.star]] || select_values == ['*']) && klass < ColumnsOnDemand::InstanceMethods
         arel.project(*arel_columns([default_select(true)]))
       else
         build_select_without_columns_on_demand(arel)        


### PR DESCRIPTION
When including an unreferenced association in a query (e.g. with `Parent.includes(:child)`), Active Record pre-loads the associated records [using `Arel.star` as the select](https://github.com/rails/rails/blob/4-2-stable/activerecord/lib/active_record/associations/preloader/association.rb#L143). This causes all the columns to be loaded, including those marked as on demand.

This pull request changes `build_select_with_columns_on_demand` so that it excludes the on demand
columns when the select of a `Relation` has been set to either `Arel.star` or `'*'`.

With the change, on demand columns will no longer be fetched when included associations are pre-loaded.