### PR TITLE
Ensure previous value is loaded when modifying on demand column

### DIFF
--- a/lib/columns_on_demand.rb
+++ b/lib/columns_on_demand.rb
@@ -107,6 +107,16 @@ module ColumnsOnDemand
       super(attr_name, &block)
     end
 
+    def write_attribute(attr_name, value)
+      ensure_loaded(attr_name)
+      super(attr_name, value)
+    end
+
+    def _write_attribute(attr_name, value)
+      ensure_loaded(attr_name)
+      super(attr_name, value)
+    end
+
     def missing_attribute(attr_name, *args)
       if columns_to_load_on_demand.include?(attr_name)
         load_attributes(attr_name)

--- a/test/columns_on_demand_test.rb
+++ b/test/columns_on_demand_test.rb
@@ -148,6 +148,13 @@ class ColumnsOnDemandTest < ActiveSupport::TestCase
     assert_equal "somefile.txt", attributes["original_filename"]
     assert_equal "This is the file data!", attributes["file_data"]
   end
+
+  test "it loads the column when changing its value" do
+    record = Implicit.first
+    record.file_data = 'This is the new file data!'
+    assert_equal "This is the file data!", record.file_data_was
+    assert_equal ["This is the file data!", "This is the new file data!"], record.changes[:file_data]
+  end
   
   test "it loads the column when generating #to_json" do
     ActiveRecord::Base.include_root_in_json = true


### PR DESCRIPTION
When modifying the value of an on-demand column the previous value is not loaded. This breaks `.changes` and indirectly auditing / undo via the paper trail gem.

Running the added test with the old code yields:

```
ColumnsOnDemandTest#test_it_loads_the_column_when_changing_its_value [test/columns_on_demand_test.rb:155]:
Expected: "This is the file data!"
  Actual: #<Object:0x00007fc023a23100>
```

The fix is to ensure the previous value is loaded before updating the attribute.